### PR TITLE
Fix for RuntimeError: dictionary changed size during iteration

### DIFF
--- a/deepwalk/graph.py
+++ b/deepwalk/graph.py
@@ -50,7 +50,7 @@ class Graph(defaultdict):
   
     t0 = time()
 
-    for v in self.keys():
+    for v in list(self.keys()):
       for other in self[v]:
         if v != other:
           self[other].append(v)


### PR DESCRIPTION
When run python deepwalk\__main__.py --format mat --matfile-variable-name Network --input some.mat --output some
I'm getting the following traceback / error:
C:\ProgramData\Anaconda35\envs\tf\lib\site-packages\smart_open\ssh.py:34: UserWarning: paramiko missing, opening SSH/SCP/SFTP paths will be disabled.  `pip install paramiko` to suppress
  warnings.warn('paramiko missing, opening SSH/SCP/SFTP paths will be disabled.  `pip install paramiko` to suppress')
C:\ProgramData\Anaconda35\envs\tf\lib\site-packages\gensim\utils.py:1197: UserWarning: detected Windows; aliasing chunkize to chunkize_serial
  warnings.warn("detected Windows; aliasing chunkize to chunkize_serial")
Traceback (most recent call last):
  File "deepwalk\__main__.py", line 165, in <module>
    sys.exit(main())
  File "deepwalk\__main__.py", line 162, in main
    process(args)
  File "deepwalk\__main__.py", line 56, in process
    G = graph.load_matfile(args.input, variable_name=args.matfile_variable_name, undirected=args.undirected)
  File "C:\some\baseline\deepwalk-master\deepwalk\graph.py", line 259, in load_matfile
    return from_numpy(mat_matrix, undirected)
  File "C:\some\baseline\deepwalk-master\deepwalk\graph.py", line 286, in from_numpy
    G.make_undirected()
  File "C:\some\baseline\deepwalk-master\deepwalk\graph.py", line 53, in make_undirected
    for v in self.keys():
RuntimeError: dictionary changed size during iteration